### PR TITLE
Dpad and Shoot to trigger

### DIFF
--- a/Assets/Inputs/csc404 prototype.inputactions
+++ b/Assets/Inputs/csc404 prototype.inputactions
@@ -16,15 +16,6 @@
                     "initialStateCheck": true
                 },
                 {
-                    "name": "DpadMove",
-                    "type": "Value",
-                    "id": "1be31428-775d-447b-8ce5-4ab23e7e9d98",
-                    "expectedControlType": "Vector2",
-                    "processors": "",
-                    "interactions": "",
-                    "initialStateCheck": true
-                },
-                {
                     "name": "Look",
                     "type": "Value",
                     "id": "10700267-f78a-4476-bb19-d01753aecf75",
@@ -59,15 +50,6 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
-                },
-                {
-                    "name": "Trigger",
-                    "type": "Value",
-                    "id": "4f96c57a-1262-4104-bc94-cbaccc848438",
-                    "expectedControlType": "Axis",
-                    "processors": "",
-                    "interactions": "",
-                    "initialStateCheck": true
                 },
                 {
                     "name": "LeftTrigger",
@@ -157,72 +139,6 @@
                 },
                 {
                     "name": "",
-                    "id": "30d81a7b-aeb1-476c-a8f8-71c2516b34bc",
-                    "path": "<Gamepad>/dpad",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": ";Gamepad",
-                    "action": "DpadMove",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "Keyboard Arrows",
-                    "id": "01da53b6-d880-450f-b47c-9981f46f36e3",
-                    "path": "2DVector",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "DpadMove",
-                    "isComposite": true,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "up",
-                    "id": "2fd96aaf-5e90-4037-8c00-f35cd8016bd8",
-                    "path": "<Keyboard>/upArrow",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": ";Keyboard&Mouse",
-                    "action": "DpadMove",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "down",
-                    "id": "a509548b-c44b-4559-a71d-422ded32c44d",
-                    "path": "<Keyboard>/downArrow",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": ";Keyboard&Mouse",
-                    "action": "DpadMove",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "left",
-                    "id": "c411c6d6-7559-4bd6-ae88-b8b80b423d84",
-                    "path": "<Keyboard>/leftArrow",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": ";Keyboard&Mouse",
-                    "action": "DpadMove",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "right",
-                    "id": "1adddfe7-23bb-47a7-9b1b-72de96f65dbd",
-                    "path": "<Keyboard>/rightArrow",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": ";Keyboard&Mouse",
-                    "action": "DpadMove",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "",
                     "id": "c1f7a91b-d0fd-4a62-997e-7fb9b69bf235",
                     "path": "<Gamepad>/rightStick",
                     "interactions": "",
@@ -306,28 +222,6 @@
                     "processors": "",
                     "groups": ";Keyboard&Mouse",
                     "action": "ItemInteract",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "25807be5-4830-4d94-852c-d0be08e30e2b",
-                    "path": "<Gamepad>/rightTrigger",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": ";Gamepad",
-                    "action": "Trigger",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "69c14966-f101-429c-904d-8bb2b1314ef5",
-                    "path": "<Keyboard>/l",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": ";Keyboard&Mouse",
-                    "action": "Trigger",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },

--- a/Assets/Inputs/csc404 prototype.inputactions
+++ b/Assets/Inputs/csc404 prototype.inputactions
@@ -77,6 +77,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": true
+                },
+                {
+                    "name": "RightTrigger",
+                    "type": "Value",
+                    "id": "21acfc87-c7b8-432a-af48-006c31d616c5",
+                    "expectedControlType": "Axis",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
                 }
             ],
             "bindings": [
@@ -341,6 +350,28 @@
                     "processors": "",
                     "groups": ";Keyboard&Mouse",
                     "action": "LeftTrigger",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "653bc734-0cc2-43d3-99f3-569bbc2a5818",
+                    "path": "<Gamepad>/rightTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "RightTrigger",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "c3cd3c71-c899-4882-b334-00a0f32eb3f3",
+                    "path": "<Keyboard>/y",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "RightTrigger",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Scripts/BlinkConsole.cs
+++ b/Assets/Scripts/BlinkConsole.cs
@@ -64,7 +64,7 @@ public class BlinkConsole : Interactable
                     danger = true;
                     Debug.Log("out of time you are sus");
                     // disable head console
-                    headConsole.disableInteract();
+                    headConsole.DisableInteract();
                 }
             }
         }
@@ -91,7 +91,7 @@ public class BlinkConsole : Interactable
         //EnableOutline();
         Debug.Log("timers reset");
 
-        headConsole.enableInteract(); // reenable head
+        headConsole.EnableInteract(); // reenable head
         danger = false; // remove flags
         warning = false; // remove flags
         GlobalPlayerUIManager.Instance.DisablePixelate(); // undo pixelate

--- a/Assets/Scripts/HandConsole.cs
+++ b/Assets/Scripts/HandConsole.cs
@@ -3,9 +3,11 @@ using UnityEngine;
 public class HandConsole : Interactable
 {
     public GameObject handRigTarget;
+    public HeadConsole headConsole; // for grapple arm jamming
     private bool _canInteract = true;
+    public bool left;
 
-    private GameObject currPlayer;
+    private GameObject _currPlayer;
 
     void Start()
     {
@@ -18,7 +20,7 @@ public class HandConsole : Interactable
         player.GetComponent<Player>().TurnOff();
         handRigTarget.GetComponent<HandMovement>().TurnOn(player);
         _canInteract = false;
-        currPlayer = player;
+        _currPlayer = player;
     }
 
     public override void Return(GameObject player)
@@ -26,7 +28,7 @@ public class HandConsole : Interactable
         player.GetComponent<Player>().TurnOn();
         handRigTarget.GetComponent<HandMovement>().TurnOff(player);
         _canInteract = true; // current player leaves
-        currPlayer = null;
+        _currPlayer = null;
     }
 
     public override bool CanInteract()
@@ -39,8 +41,9 @@ public class HandConsole : Interactable
         hoverMessage = "[GRAPPL DISABLED] Enter Arm to repair";
         msgColour = new Color(1, 0, 0, 1);
         outlineColour = new Color(1, 0, 0, 1);
-        handRigTarget.GetComponent<HandMovement>().JamArm(true);
-        currPlayer = null;
+        // handRigTarget.GetComponent<HandMovement>().JamArm(true);
+        headConsole.JamArm(left, true);
+        _currPlayer = null;
     }
 
     public void EnableInteract()
@@ -49,6 +52,7 @@ public class HandConsole : Interactable
         hoverMessage = "Control Arm";
         msgColour = new Color(1, 1, 1, 1);
         outlineColour = new Color(1, 1, 1, 1);
-        handRigTarget.GetComponent<HandMovement>().JamArm(false);
+        // handRigTarget.GetComponent<HandMovement>().JamArm(false);
+        headConsole.JamArm(left, false);
     }
 }

--- a/Assets/Scripts/HandConsole.cs
+++ b/Assets/Scripts/HandConsole.cs
@@ -38,7 +38,7 @@ public class HandConsole : Interactable
 
     public void DisableInteract()
     {
-        hoverMessage = "[GRAPPL DISABLED] Enter Arm to repair";
+        hoverMessage = "[GRAPPLE DISABLED] Enter Arm to repair";
         msgColour = new Color(1, 0, 0, 1);
         outlineColour = new Color(1, 0, 0, 1);
         // handRigTarget.GetComponent<HandMovement>().JamArm(true);

--- a/Assets/Scripts/HandMovement.cs
+++ b/Assets/Scripts/HandMovement.cs
@@ -1,17 +1,15 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
-using UnityEngine.Rendering.Universal;
-using static UnityEngine.Timeline.AnimationPlayableAsset;
 
 public class HandMovement : MonoBehaviour
 {
     public float speed = 5f;
 
     private InputAction _moveAction;
-    private InputAction _dpadAction;
+        private InputAction _leftTriggerAction;
+    private InputAction _rightTriggerAction;        
     private InputAction _lookAction;
     private InputAction _interactAction;
-    private InputAction _rightTriggerAction;
 
     public Vector3 movement = Vector3.zero;
     private Vector3 _ogPosition;
@@ -50,11 +48,13 @@ public class HandMovement : MonoBehaviour
         {
             // hand rigid body movement
             Vector2 stickMove = _moveAction.ReadValue<Vector2>();
-            Vector2 dpadMove = _dpadAction.ReadValue<Vector2>();
             Vector3 stickMovement = new Vector3(stickMove.x, stickMove.y, 0);
-            Vector3 dpadMovement = new Vector3(0, 0, dpadMove.y) * -1;
-
-            movement += (stickMovement + dpadMovement) * Time.deltaTime;
+            
+            float leftTrigger = _leftTriggerAction.ReadValue<float>();
+            float rightTrigger = _rightTriggerAction.ReadValue<float>();
+            Vector3 triggerMovement = new Vector3(0, 0, leftTrigger - rightTrigger);
+            
+            movement += (stickMovement + triggerMovement) * Time.deltaTime;
             // movement done in FixedUpdate
 
             // rotation movement (done in LateUpdate)
@@ -64,7 +64,7 @@ public class HandMovement : MonoBehaviour
             wristRotateY = Mathf.Clamp(wristRotateY, -90f, 90f);
 
             // changed from movement.magnitude to this addition because movement is now += instead of =
-            bool movingNow = ((stickMovement + dpadMovement).magnitude > 0.5f) || (lookMove.magnitude > 0.3f);
+            bool movingNow = ((stickMovement + triggerMovement).magnitude > 0.5f) || (lookMove.magnitude > 0.3f);
 
             // Movement started
             if (movingNow && !_isMoving)
@@ -155,8 +155,8 @@ public class HandMovement : MonoBehaviour
         _currPlayer = playerUsing;
         var input = _currPlayer.GetComponent<PlayerInput>();
         _moveAction = input.actions.FindAction("Move");
-        _dpadAction = input.actions.FindAction("DpadMove");
-        _lookAction = input.actions.FindAction("Look");
+        _leftTriggerAction = input.actions.FindAction("LeftTrigger");
+        _rightTriggerAction = input.actions.FindAction("RightTrigger");        _lookAction = input.actions.FindAction("Look");
         _interactAction = input.actions.FindAction("ItemInteract");
         _disable = true;
     }

--- a/Assets/Scripts/HandMovement.cs
+++ b/Assets/Scripts/HandMovement.cs
@@ -14,13 +14,12 @@ public class HandMovement : MonoBehaviour
     private InputAction _rightTriggerAction;
 
     public Vector3 movement = Vector3.zero;
-    private Vector3 ogPosition;
+    private Vector3 _ogPosition;
     private bool _disable;
 
     private bool _isMoving;
     public AudioSource moveSource;
     public AudioSource stopSource;
-    public AudioSource hookSource;
 
     private GameObject _currPlayer;
 
@@ -39,15 +38,10 @@ public class HandMovement : MonoBehaviour
 
     [SerializeField] private GameObject grappleArmSpline;
     public bool left;
-    private bool _shot;
-
-    private bool _jammed;
-
+    
     private void Start()
     {
-        _shot = false;
-        _jammed = false;
-        ogPosition = transform.localPosition;
+        _ogPosition = transform.localPosition;
     }
 
     private void Update()
@@ -128,13 +122,13 @@ public class HandMovement : MonoBehaviour
     {
         if (left)
         {
-            transform.localPosition = movement * speed + ogPosition;
+            transform.localPosition = movement * speed + _ogPosition;
         }
         else
         {
             Vector3 tmpMvt = movement;
             tmpMvt.x *= -1.0f;
-            transform.localPosition = tmpMvt * speed + ogPosition;
+            transform.localPosition = tmpMvt * speed + _ogPosition;
         }
     }
 

--- a/Assets/Scripts/HandMovement.cs
+++ b/Assets/Scripts/HandMovement.cs
@@ -12,7 +12,6 @@ public class HandMovement : MonoBehaviour
     private InputAction _lookAction;
     private InputAction _interactAction;
     private InputAction _rightTriggerAction;
-    private InputAction _leftTriggerAction;
 
     public Vector3 movement = Vector3.zero;
     private Vector3 ogPosition;
@@ -40,14 +39,14 @@ public class HandMovement : MonoBehaviour
 
     [SerializeField] private GameObject grappleArmSpline;
     public bool left;
-    private bool shot;
+    private bool _shot;
 
-    private bool jammed;
+    private bool _jammed;
 
     private void Start()
     {
-        shot = false;
-        jammed = false;
+        _shot = false;
+        _jammed = false;
         ogPosition = transform.localPosition;
     }
 
@@ -115,30 +114,6 @@ public class HandMovement : MonoBehaviour
                 Debug.Log("interaction " + _toInteractObj + _canInteract);
                 StopInteractingWithObject(_currObj);
             }
-
-            // TODO move to head console
-            if (_rightTriggerAction.ReadValue<float>() > 0.1f && !jammed)
-            {
-                if (!shot)
-                {
-                    shot = true;
-                    EmergencyEvent.Instance.IncrementCount(left);
-
-                    if (hookSource != null)
-                        hookSource.Play();
-                }
-
-                grappleArmSpline.GetComponent<SplineController>().SetExtending();
-            }
-            else
-            {
-                if (shot)
-                {
-                    shot = false;
-                }
-
-                grappleArmSpline.GetComponent<SplineController>().SetRetracting();
-            }
         }
         else
         {
@@ -189,8 +164,6 @@ public class HandMovement : MonoBehaviour
         _dpadAction = input.actions.FindAction("DpadMove");
         _lookAction = input.actions.FindAction("Look");
         _interactAction = input.actions.FindAction("ItemInteract");
-        _rightTriggerAction = input.actions.FindAction("Trigger");
-        _leftTriggerAction = input.actions.FindAction("LeftTrigger");
         _disable = true;
     }
 
@@ -216,11 +189,6 @@ public class HandMovement : MonoBehaviour
         Debug.Log("Stopping interaction with " + interactableObject);
         interactableObject.StopInteractWithHand(this);
         _currObj = null;
-    }
-
-    public void JamArm(bool state)
-    {
-        jammed = state;
     }
 
 }

--- a/Assets/Scripts/HeadConsole.cs
+++ b/Assets/Scripts/HeadConsole.cs
@@ -9,10 +9,66 @@ public class HeadConsole : Interactable
     [SerializeField] private Quaternion camAngle; // current robot head angle
 
     private bool _canInteract = true;
+    
+    // for grapple arm
+    [SerializeField] private GameObject leftGrappleArmSpline;
+    [SerializeField] private GameObject rightGrappleArmSpline;
+
+    private bool _leftJammed, _rightJammed;
+    private bool _leftShot, _rightShot;
+
+    private InputAction _leftTriggerAction, _rightTriggerAction;
+    private GameObject _currPlayer;
 
     void Start()
     {
         _splitscreenUIHandler = FindAnyObjectByType<SplitscreenUIHandler>();
+        // for grapple arm
+        _leftJammed = _rightJammed = false;
+        _leftShot = _rightShot = false;
+    }
+    
+    // for grapple arm
+    void Update()
+    {
+        if (_currPlayer != null)
+        {
+            if (_leftTriggerAction != null && _leftTriggerAction.ReadValue<float>() > 0.1f && !_leftJammed)
+            {
+                if (!_leftShot)
+                {
+                    _leftShot = true;
+                    EmergencyEvent.Instance.IncrementCount(true); // or pass correct value
+                    // Optionally play hook sound here if needed
+                }
+                leftGrappleArmSpline.GetComponent<SplineController>().SetExtending();
+            }
+            else
+            {
+                if (_leftShot)
+                {
+                    _leftShot = false;
+                }
+                leftGrappleArmSpline.GetComponent<SplineController>().SetRetracting();
+            }
+            
+            // Right arm
+            if (_leftTriggerAction != null && _rightTriggerAction.ReadValue<float>() > 0.1f && !_rightJammed)
+            {
+                if (!_rightShot)
+                {
+                    _rightShot = true;
+                    EmergencyEvent.Instance.IncrementCount(false);
+                }
+                rightGrappleArmSpline.GetComponent<SplineController>().SetExtending();
+            }
+            else
+            {
+                if (_rightShot)
+                    _rightShot = false;
+                rightGrappleArmSpline.GetComponent<SplineController>().SetRetracting();
+            }
+        }
     }
     
     public override void Interact(GameObject player)
@@ -23,6 +79,12 @@ public class HeadConsole : Interactable
         player.GetComponent<Player>().TurnOff();
         player.GetComponent<Player>().switchToHead(exteriorCamera);
         _canInteract = false;
+        
+        // for grapple arm
+        _currPlayer = player;
+        var input = _currPlayer.GetComponent<PlayerInput>();
+        _leftTriggerAction = input.actions.FindAction("LeftTrigger");
+        _rightTriggerAction = input.actions.FindAction("RightTrigger");
     }
 
     public override void Return(GameObject player)
@@ -33,13 +95,17 @@ public class HeadConsole : Interactable
         player.GetComponent<Player>().switchOffHead();
 
         _canInteract = true;
+        // for grapple arm
+        _currPlayer = null;
+        _leftTriggerAction = null;
+        _rightTriggerAction = null;
     }
     public override bool CanInteract()
     {
         return _canInteract;
     }
 
-    public void disableInteract()
+    public void DisableInteract()
     {
         _canInteract = false;
         hoverMessage = "[DISABLED] Please Blink";
@@ -47,11 +113,20 @@ public class HeadConsole : Interactable
         outlineColour = new Color(1, 0, 0, 1);
     }
 
-    public void enableInteract()
+    public void EnableInteract()
     {
         _canInteract = true;
         hoverMessage = "Control Head";
         msgColour = new Color(1, 1, 1, 1);
         outlineColour = new Color(1, 1, 1, 1);
+    }
+    
+    // for grapple arm
+    public void JamArm(bool left, bool state)
+    {
+        if (left)
+            _leftJammed = state;
+        else
+            _rightJammed = state;
     }
 }

--- a/Assets/Scripts/HeadConsole.cs
+++ b/Assets/Scripts/HeadConsole.cs
@@ -10,15 +10,15 @@ public class HeadConsole : Interactable
 
     private bool _canInteract = true;
     
-    // for grapple arm
     [SerializeField] private GameObject leftGrappleArmSpline;
     [SerializeField] private GameObject rightGrappleArmSpline;
 
     private bool _leftJammed, _rightJammed;
     private bool _leftShot, _rightShot;
-
     private InputAction _leftTriggerAction, _rightTriggerAction;
     private GameObject _currPlayer;
+    
+    public AudioSource hookSource;
 
     void Start()
     {
@@ -28,18 +28,21 @@ public class HeadConsole : Interactable
         _leftShot = _rightShot = false;
     }
     
-    // for grapple arm
+    // for grapple arm, check trigger input to shoot or retract
     void Update()
     {
         if (_currPlayer != null)
         {
+            // Left arm
             if (_leftTriggerAction != null && _leftTriggerAction.ReadValue<float>() > 0.1f && !_leftJammed)
             {
                 if (!_leftShot)
                 {
                     _leftShot = true;
                     EmergencyEvent.Instance.IncrementCount(true); // or pass correct value
-                    // Optionally play hook sound here if needed
+                    
+                    if (hookSource != null)
+                        hookSource.Play();
                 }
                 leftGrappleArmSpline.GetComponent<SplineController>().SetExtending();
             }
@@ -59,6 +62,9 @@ public class HeadConsole : Interactable
                 {
                     _rightShot = true;
                     EmergencyEvent.Instance.IncrementCount(false);
+                    
+                    if (hookSource != null)
+                        hookSource.Play();
                 }
                 rightGrappleArmSpline.GetComponent<SplineController>().SetExtending();
             }
@@ -95,6 +101,7 @@ public class HeadConsole : Interactable
         player.GetComponent<Player>().switchOffHead();
 
         _canInteract = true;
+        
         // for grapple arm
         _currPlayer = null;
         _leftTriggerAction = null;
@@ -121,7 +128,7 @@ public class HeadConsole : Interactable
         outlineColour = new Color(1, 1, 1, 1);
     }
     
-    // for grapple arm
+    // for grapple arm - to be called by HandConsole when arm is broken or fixed
     public void JamArm(bool left, bool state)
     {
         if (left)


### PR DESCRIPTION
1. Grapple hands now shoot by head console player - left trigger to shoot left hand, right trigger to shoot right hand
2. Hand Z-axis movement (forward/backward) now by triggers instead of dpad - right trigger forward, left trigger backward

- Input actions: added values (float) "LeftTrigger" and "RightTrigger", "DpadMove" and "Trigger" removed (both not used else where)
- In scene: refactored all script bindings
- HandConsole.cs: calling JamArm now from head console instead of hand rig target
-- now reference HeadConsole object & use "left" value of grapple hand
- HandMovement.cs: changed all dpad to left/right trigger & removed shooting arms Update and JamArm
- HeadConsole.cs: reference left/right GrappleArmSplines & add Update for shoot arm with audio call & added JamArm here