### PR TITLE
Make grabbing more resilient

### DIFF
--- a/Assets/Scripts/Ball.cs
+++ b/Assets/Scripts/Ball.cs
@@ -45,7 +45,7 @@ public class Ball : InteractableObject
         groundSfx.Stop();
     }
 
-    public override void InteractWithHand(Transform obj, HandMovement target)
+    public override InteractableObject InteractWithHand(Transform obj, HandMovement target)
     {
         if (canInteract && canPickup)
         {
@@ -71,7 +71,10 @@ public class Ball : InteractableObject
             target.handAnimator.SetTrigger("Grab"); // sets current hand to hold anim
 
             grappleCollider.enabled = false;
+            return this;
         }
+
+        return null;
     }
 
     public override void StopInteractWithHand(HandMovement target)

--- a/Assets/Scripts/Ball.cs
+++ b/Assets/Scripts/Ball.cs
@@ -67,9 +67,7 @@ public class Ball : InteractableObject
             rg.interpolation = RigidbodyInterpolation.None;
             triggerCollider.enabled = false;
             Debug.Log("pickup success");
-
-            target.SetTargetCurrentObject(this);
-
+            
             target.handAnimator.SetTrigger("Grab"); // sets current hand to hold anim
 
             grappleCollider.enabled = false;

--- a/Assets/Scripts/Evidence.cs
+++ b/Assets/Scripts/Evidence.cs
@@ -31,7 +31,7 @@ public class Evidence : InteractableObject, IPooledObject
         grabbed = false;
     }
 
-    public override void InteractWithHand(Transform obj, HandMovement target)
+    public override InteractableObject InteractWithHand(Transform obj, HandMovement target)
     {
         if (!grabbed)
         {
@@ -67,6 +67,7 @@ public class Evidence : InteractableObject, IPooledObject
             StartCoroutine(DisappearRoutine());
         }
 
+        return null;
     }
 
     public void SetEvidenceSpawner(EvidenceSpawner evidenceSpawner)

--- a/Assets/Scripts/GrabbableObject.cs
+++ b/Assets/Scripts/GrabbableObject.cs
@@ -18,7 +18,7 @@ public class GrabbableObject : InteractableObject
         ogParent = transform.parent;
     }
 
-    public override void InteractWithHand(Transform obj, HandMovement target)
+    public override InteractableObject InteractWithHand(Transform obj, HandMovement target)
     {
         if (canInteract && canPickup)
         {
@@ -38,7 +38,10 @@ public class GrabbableObject : InteractableObject
             target.handAnimator.SetTrigger("Grab"); // sets current hand to hold anim
 
             handMovement = target;
+            return this;
         }
+
+        return null;
     }
 
     public override void StopInteractWithHand(HandMovement target)

--- a/Assets/Scripts/GrabbableObject.cs
+++ b/Assets/Scripts/GrabbableObject.cs
@@ -36,7 +36,6 @@ public class GrabbableObject : InteractableObject
             triggerCollider.enabled = false;
 
             target.handAnimator.SetTrigger("Grab"); // sets current hand to hold anim
-            target.SetTargetCurrentObject(this);
 
             handMovement = target;
         }

--- a/Assets/Scripts/HandMovement.cs
+++ b/Assets/Scripts/HandMovement.cs
@@ -606,10 +606,12 @@ public class HandMovement : MonoBehaviour
     public void StopInteractingWithObject(InteractableObject interactableObject)
     {
         string handType = left ? "left" : "right";
-        if (interactableObject.canDrop)
+        // Drop the current object 1. if we can drop or 2. as a failsafe if our current object is not active
+        if (interactableObject.canDrop || (currObj != null && !currObj.isActiveAndEnabled))
         {
             Debug.Log(handType + " hand stopping interaction with " + interactableObject);
             interactableObject.StopInteractWithHand(this);
+            handAnimator.SetTrigger("Neutral");
             currObj = null;
         }
         else

--- a/Assets/Scripts/HandMovement.cs
+++ b/Assets/Scripts/HandMovement.cs
@@ -596,8 +596,8 @@ public class HandMovement : MonoBehaviour
             return;
         }
         Debug.Log(handType + " hand interacting with " + interactableObject);
-        interactableObject.InteractWithHand(wristBone, this);
-        currObj = interactableObject;
+        var objInteractingWith = interactableObject.InteractWithHand(wristBone, this);
+        currObj = objInteractingWith;
     }
 
     /// <summary>

--- a/Assets/Scripts/HandMovement.cs
+++ b/Assets/Scripts/HandMovement.cs
@@ -58,7 +58,7 @@ public class HandMovement : MonoBehaviour
     // Interactable object information
     public InteractableObject currObj;    // currently interacting with hand
     // Ordered list of objects available to interact. First interactable object is priority for hand
-    [SerializeField] private List<InteractableObject> _interactables = new List<InteractableObject>();
+    [SerializeField] private List<InteractableObject> candidateInteractables = new List<InteractableObject>();
     private Dictionary<InteractableObject, InteractableObjectData> _interactablesData = new Dictionary<InteractableObject, InteractableObjectData>();
     // A delay counter for auto-picking up stuff after dropping an item
     private float _pickupDelayCounter;
@@ -496,7 +496,7 @@ public class HandMovement : MonoBehaviour
             Debug.LogWarning("Duplicate interactableObject attempted to add to candidates " + interactableObj);
             return;
         }
-        _interactables.Add(interactableObj);
+        candidateInteractables.Add(interactableObj);
         InteractableObjectData interactableData = new InteractableObjectData(interactableObj);
         _interactablesData.Add(interactableObj, interactableData);
     }
@@ -510,11 +510,11 @@ public class HandMovement : MonoBehaviour
         {
             Debug.LogWarning("Game object "  + interactableObj + " was removed from hand interactables but not found");
         }
-        if (!_interactables.Contains(interactableObj))
+        if (!candidateInteractables.Contains(interactableObj))
         {
             Debug.LogWarning("Game object "  + interactableObj + " was removed from hand interactables but not found");
         }
-        _interactables.Remove(interactableObj);
+        candidateInteractables.Remove(interactableObj);
         _interactablesData.Remove(interactableObj);
     }
     
@@ -526,31 +526,31 @@ public class HandMovement : MonoBehaviour
     {
         string handType = left ? "left" : "right";
         InteractableObject interactableObj = null;
-        for (int i = 0; i < _interactables.Count; i++)
+        for (int i = 0; i < candidateInteractables.Count; i++)
         {
-            InteractableObject obj = _interactables[i];
+            InteractableObject obj = candidateInteractables[i];
             // hacks to ensure interaction not stuck
             if (obj == null)
             {
-                _interactables.RemoveAt(i);
+                candidateInteractables.RemoveAt(i);
                 i--;
                 Debug.LogWarning(handType + " hand pruned missing gameobject from interactable candidate list");
             }
             else if (obj.isInHand())
             {
-                _interactables.RemoveAt(i);
+                candidateInteractables.RemoveAt(i);
                 i--;
                 Debug.LogWarning(handType + " hand had object that was in a hand");
             }
             else if (!obj.gameObject.activeSelf)
             {
-                _interactables.RemoveAt(i);
+                candidateInteractables.RemoveAt(i);
                 i--;
                 Debug.LogWarning(handType + " hand had object that was inactive");
             }
             else if (obj.canInteract == false)
             {
-                _interactables.RemoveAt(i);
+                candidateInteractables.RemoveAt(i);
                 i--;
                 Debug.LogWarning(handType + " hand had object that had canInteract false");
             }
@@ -590,8 +590,14 @@ public class HandMovement : MonoBehaviour
     private void InteractWithObject(InteractableObject interactableObject)
     {
         string handType = left ? "left" : "right";
+        if (currObj != null)
+        {
+            Debug.LogWarning("Tried to interact with: " + interactableObject + " but had " + currObj + " in " + handType + " hand");
+            return;
+        }
         Debug.Log(handType + " hand interacting with " + interactableObject);
         interactableObject.InteractWithHand(wristBone, this);
+        currObj = interactableObject;
     }
 
     /// <summary>
@@ -610,14 +616,5 @@ public class HandMovement : MonoBehaviour
         {
             Debug.Log(handType + " hand cannot stop interaction with " + interactableObject);
         }
-    }
-
-    // TODO: this should probably not be exposed.
-    /// <summary>
-    /// Set the current object this hand is holding.
-    /// </summary>
-    public void SetTargetCurrentObject(InteractableObject obj)
-    {
-        currObj = obj;
     }
 }

--- a/Assets/Scripts/InteractableObject.cs
+++ b/Assets/Scripts/InteractableObject.cs
@@ -63,9 +63,16 @@ public abstract class InteractableObject : MonoBehaviour
         }
     }
 
-    public virtual void InteractWithHand(Transform wrist, HandMovement target)
+    /// <summary>
+    /// Interact with the robot arm's hand in some way. Returns the object the hand should consider it is interacting with.
+    /// </summary>
+    /// <param name="wrist">The transform of the hand base (wrist)</param>
+    /// <param name="target">The hand this object is interacting with</param>
+    /// <returns>The object the hand is interacting with after triggering an interact on this object.</returns>
+    public virtual InteractableObject InteractWithHand(Transform wrist, HandMovement target)
     {
         inHand = true;
+        return null;
     }
 
     public virtual void StopInteractWithHand(HandMovement target)

--- a/Assets/Scripts/Level 1/AttachPoint.cs
+++ b/Assets/Scripts/Level 1/AttachPoint.cs
@@ -1,3 +1,5 @@
+using System;
+using UnityEditor.PackageManager;
 using UnityEngine;
 
 public class AttachPoint : InteractableObject
@@ -5,6 +7,12 @@ public class AttachPoint : InteractableObject
     [SerializeField] private Tray tray;
     public bool isHeld;
     public HandMovement currentHand;
+
+    public void Awake()
+    {
+        // Is old script and has been modified without test.
+        throw new NotImplementedException();
+    }
 
     public override void InteractWithHand(Transform wrist, HandMovement target)
     {
@@ -21,7 +29,6 @@ public class AttachPoint : InteractableObject
         canPickup = false;
 
         // Tell tray a hand grabbed this attach point
-        target.SetTargetCurrentObject(this);
         target.handAnimator.SetTrigger("Pot");
         target.FreezeWristPosition(true);
         tray.OnAttachPointGrabbed();
@@ -33,7 +40,6 @@ public class AttachPoint : InteractableObject
         Debug.Log("Stop ATTACH and  " + target);
         if (!isHeld || currentHand != target) return;
 
-        target.SetTargetCurrentObject(null);
         target.FreezeWristPosition(false);
         // currentHand.attachedCheckGrapple();
         target.handAnimator.SetTrigger("Neutral");
@@ -56,7 +62,6 @@ public class AttachPoint : InteractableObject
     {
         if (currentHand != null)
         {
-            currentHand.SetTargetCurrentObject(null);
             currentHand.FreezeWristPosition(false);
             currentHand.DisableGrapple(false);
             currentHand.handAnimator.SetTrigger("Neutral");

--- a/Assets/Scripts/Level 1/AttachPoint.cs
+++ b/Assets/Scripts/Level 1/AttachPoint.cs
@@ -14,10 +14,10 @@ public class AttachPoint : InteractableObject
         throw new NotImplementedException();
     }
 
-    public override void InteractWithHand(Transform wrist, HandMovement target)
+    public override InteractableObject InteractWithHand(Transform wrist, HandMovement target)
     {
         base.InteractWithHand(wrist, target);
-        if (!canInteract || isHeld) return;
+        if (!canInteract || isHeld) return null;
 
         isHeld = true;
         currentHand = target;
@@ -32,6 +32,8 @@ public class AttachPoint : InteractableObject
         target.handAnimator.SetTrigger("Pot");
         target.FreezeWristPosition(true);
         tray.OnAttachPointGrabbed();
+
+        return this;
     }
 
     public override void StopInteractWithHand(HandMovement target)

--- a/Assets/Scripts/Level 1/Bag.cs
+++ b/Assets/Scripts/Level 1/Bag.cs
@@ -33,7 +33,7 @@ public class Bag : InteractableObject
         ScoreKeeper.Instance.AddScoring("Discarded food", 5, false, true, 0);
     }
 
-    public override void InteractWithHand(Transform obj, HandMovement target)
+    public override InteractableObject InteractWithHand(Transform obj, HandMovement target)
     {
         if (canInteract && canPickup)
         {
@@ -54,7 +54,11 @@ public class Bag : InteractableObject
             Debug.Log("pickup success");
 
             target.handAnimator.SetTrigger("Pot"); // sets current hand to pot anim
+
+            return this;
         }
+
+        return null;
     }
 
     public override void StopInteractWithHand(HandMovement target)

--- a/Assets/Scripts/Level 1/Bag.cs
+++ b/Assets/Scripts/Level 1/Bag.cs
@@ -53,7 +53,6 @@ public class Bag : InteractableObject
 
             Debug.Log("pickup success");
 
-            target.SetTargetCurrentObject(this);
             target.handAnimator.SetTrigger("Pot"); // sets current hand to pot anim
         }
     }

--- a/Assets/Scripts/Level 1/CakeSlice.cs
+++ b/Assets/Scripts/Level 1/CakeSlice.cs
@@ -45,7 +45,6 @@ public class CakeSlice : InteractableObject
             triggerCollider.enabled = false;
 
             target.handAnimator.SetTrigger("Grab"); // sets current hand to hold anim
-            target.SetTargetCurrentObject(this);
         }
     }
 

--- a/Assets/Scripts/Level 1/CakeSlice.cs
+++ b/Assets/Scripts/Level 1/CakeSlice.cs
@@ -23,7 +23,7 @@ public class CakeSlice : InteractableObject
         first = true;
     }
 
-    public override void InteractWithHand(Transform obj, HandMovement target)
+    public override InteractableObject InteractWithHand(Transform obj, HandMovement target)
     {
         if (canInteract && canPickup)
         {
@@ -45,7 +45,11 @@ public class CakeSlice : InteractableObject
             triggerCollider.enabled = false;
 
             target.handAnimator.SetTrigger("Grab"); // sets current hand to hold anim
+
+            return this;
         }
+
+        return null;
     }
 
     public override void StopInteractWithHand(HandMovement target)

--- a/Assets/Scripts/Level 1/CoffeePot.cs
+++ b/Assets/Scripts/Level 1/CoffeePot.cs
@@ -156,7 +156,6 @@ public class CoffeePot : InteractableObject
             triggerCollider.enabled = false;
             Debug.Log("pickup success");
 
-            target.SetTargetCurrentObject(this);
             target.handAnimator.SetTrigger("Pot"); // sets current hand to pot anim
 
             grappleCollider.enabled = false;

--- a/Assets/Scripts/Level 1/CoffeePot.cs
+++ b/Assets/Scripts/Level 1/CoffeePot.cs
@@ -136,7 +136,7 @@ public class CoffeePot : InteractableObject
             coffeeSfx.Stop();
     }
 
-    public override void InteractWithHand(Transform obj, HandMovement target)
+    public override InteractableObject InteractWithHand(Transform obj, HandMovement target)
     {
         if (canInteract && canPickup)
         {
@@ -161,7 +161,11 @@ public class CoffeePot : InteractableObject
             grappleCollider.enabled = false;
 
             if (allowBurnArm) StartCoroutine(BurnArm());
+
+            return this;
         }
+
+        return null;
     }
 
     public override void StopInteractWithHand(HandMovement target)

--- a/Assets/Scripts/Level 1/Food.cs
+++ b/Assets/Scripts/Level 1/Food.cs
@@ -37,7 +37,7 @@ public class Food : InteractableObject
         ScoreKeeper.Instance.AddScoring("Spaghetti completion", 2, true, false, totalBites);
     }
 
-    public override void InteractWithHand(Transform wrist, HandMovement target)
+    public override InteractableObject InteractWithHand(Transform wrist, HandMovement target)
     {
         if (foodBiteCount < totalBites && canPickup)
         {
@@ -66,13 +66,13 @@ public class Food : InteractableObject
 
             // Turn off outline when food bite is picked up (until another hover turns it back on)
             DisableOutline();
+            return foodBite;
         }
-        else
-        {
-            Debug.Log("No more food bites!");
-            target.StopInteractingWithObject(this);
-            canPickup = false;
-        }
+
+        Debug.Log("No more food bites!");
+        target.StopInteractingWithObject(this);
+        canPickup = false;
+        return null;
     }
 
     protected override void OnTriggerEnter(Collider other)

--- a/Assets/Scripts/Level 1/FoodBite.cs
+++ b/Assets/Scripts/Level 1/FoodBite.cs
@@ -47,7 +47,7 @@ public class FoodBite : InteractableObject, IPooledObject
         bag?.DisableOutline();
     }
 
-    public override void InteractWithHand(Transform obj, HandMovement target)
+    public override InteractableObject InteractWithHand(Transform obj, HandMovement target)
     {
         if (canInteract && canPickup)
         {
@@ -65,7 +65,11 @@ public class FoodBite : InteractableObject, IPooledObject
             handMovement = target;
 
             if (bag != null) bag.EnableOutline();
+
+            return this;
         }
+
+        return null;
     }
 
     public override void StopInteractWithHand(HandMovement target)

--- a/Assets/Scripts/Level 1/FoodBite.cs
+++ b/Assets/Scripts/Level 1/FoodBite.cs
@@ -44,6 +44,7 @@ public class FoodBite : InteractableObject, IPooledObject
 
     private void OnDestroy()
     {
+        canDrop = true;
         bag?.DisableOutline();
     }
 

--- a/Assets/Scripts/Level 1/FoodBite.cs
+++ b/Assets/Scripts/Level 1/FoodBite.cs
@@ -62,7 +62,6 @@ public class FoodBite : InteractableObject, IPooledObject
             Debug.Log("pickup success");
 
             target.handAnimator.SetTrigger("Pot"); // sets current hand to hold anim
-            target.SetTargetCurrentObject(this);
             handMovement = target;
 
             if (bag != null) bag.EnableOutline();

--- a/Assets/Scripts/Phone.cs
+++ b/Assets/Scripts/Phone.cs
@@ -28,7 +28,7 @@ public class Phone : InteractableObject
         first = true;
     }
 
-    public override void InteractWithHand(Transform obj, HandMovement target)
+    public override InteractableObject InteractWithHand(Transform obj, HandMovement target)
     {
         if (canInteract && canPickup)
         {
@@ -70,7 +70,11 @@ public class Phone : InteractableObject
             }
 
             grappleCollider.enabled = false;
+
+            return this;
         }
+
+        return null;
     }
 
     public override void StopInteractWithHand(HandMovement target)

--- a/Assets/Scripts/Phone.cs
+++ b/Assets/Scripts/Phone.cs
@@ -44,9 +44,7 @@ public class Phone : InteractableObject
             rg.isKinematic = true;
             triggerCollider.enabled = false;
             Debug.Log("pickup success");
-
-            target.SetTargetCurrentObject(this);
-
+            
             target.oppositeHandAnimator.SetTrigger("Point"); // sets the opposite hand to point
             target.handAnimator.SetTrigger("Hold"); // sets current hand to hold anim
 


### PR DESCRIPTION
Update the grabbing to be more resilient to getting ghost objects in the hand.

Do this by not exposing the method to set the `currObj` var in the Hand (`HandMovement` script) to any methods. Instead, the `InteractWithHand` method reports what `InteractableObject` the hand will be holding after interacting with this object.

Also an extra failsafe and visual clear of the hand animator.